### PR TITLE
Fixed startup issue with missing log file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ ADD     ./graphite/local_settings.py /opt/graphite/webapp/graphite/local_setting
 ADD     ./graphite/carbon.conf /opt/graphite/conf/carbon.conf
 ADD     ./graphite/storage-schemas.conf /opt/graphite/conf/storage-schemas.conf
 ADD     ./graphite/storage-aggregation.conf /opt/graphite/conf/storage-aggregation.conf
+RUN     mkdir -p /opt/graphite/storage/log/webapp
+RUN     touch /opt/graphite/storage/log/webapp/info.log
 RUN     mkdir -p /opt/graphite/storage/whisper
 RUN     touch /opt/graphite/storage/graphite.db /opt/graphite/storage/index
 RUN     chown -R www-data /opt/graphite/storage


### PR DESCRIPTION
In some cases info.log wouldn't be created and graphite wouldn't load